### PR TITLE
docs: fixed broken link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Campers social site
 
 ## The beginning
-Using the instructions in the Moments walkthrough project, this project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app)
+Using the instructions in the Moments walkthrough project, this project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
 The boilerplate code from Moments is the starting point of this project. 
 
 ## Available Scripts

--- a/README.md
+++ b/README.md
@@ -1,12 +1,8 @@
-<h1>Campers social site</h1>
+# Campers social site
 
-<h2>The beginning</h2>
-Using the instructions in the Moments walkthrough project, this project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
-
+## The beginning
+Using the instructions in the Moments walkthrough project, this project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app)
 The boilerplate code from Moments is the starting point of this project. 
-
-
-
 
 ## Available Scripts
 


### PR DESCRIPTION
I saw you had a broken link in the README.md file, so I fixed it.

I replaced the html tags with the markdown way of displaying headers, and that made the link work again.